### PR TITLE
allow to install with 2.4.0dev

### DIFF
--- a/yomikomu.gemspec
+++ b/yomikomu.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '~> 2.3.0dev'
+  spec.required_ruby_version = '>= 2.3.0dev'
   spec.add_runtime_dependency 'mmapped_string' if /linux/ =~ RUBY_PLATFORM
 
   spec.add_development_dependency "bundler", "~> 1.10"


### PR DESCRIPTION
I got following error with ruby 2.4.0dev.

```
yomikomu requires Ruby version ~> 2.3.0dev.
```
